### PR TITLE
Removed outdated code

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,4 @@
-# -*- encoding : utf-8 -*-
-if Rails::VERSION::MAJOR < 3
-  ActionController::Routing::Routes.draw do |map|
-    map.connect 'work_load/:action/:id', :controller => :work_load
-  end
-else
+
+RedmineApp::Application.routes.draw do
   match 'work_load/(:action(/:id))', :controller => 'work_load'
-end
+end 


### PR DESCRIPTION
Well, I think that there won't be any support for Rails 2 or later, doesn't it? As Redmine itself is shifting to Rails 4 and personally the latest supported Versions of Redmine just run with Rails 3.2.x, this won't be needed, what do you think?
