### PR TITLE
Added groups to make it easy to filter users

### DIFF
--- a/app/controllers/work_load_controller.rb
+++ b/app/controllers/work_load_controller.rb
@@ -28,6 +28,9 @@ class WorkLoadController < ApplicationController
     @issuesForWorkload = ListUser::getOpenIssuesForUsers(@usersToDisplay)
     @monthsToRender = ListUser::getMonthsInTimespan(@timeSpanToDisplay)
     @workloadData   = ListUser::getHoursPerUserIssueAndDay(@issuesForWorkload, @timeSpanToDisplay, @today)
+
+    # DX_Sadaf: adding select box for groups
+    @groups = Group.preload(:users).order('lastname').all
   end
 
 

--- a/app/helpers/workload_filters_helper.rb
+++ b/app/helpers/workload_filters_helper.rb
@@ -12,4 +12,17 @@ module WorkloadFiltersHelper
 
     return result.html_safe
   end
+
+  def group_params_nil?
+    if params.nil?
+      return true
+    elsif params[:workload].nil?
+      return true
+    elsif params[:workload][:groups].nil?
+      return true
+    else
+      return false
+    end
+  end
+
 end

--- a/app/views/work_load/_filters.erb
+++ b/app/views/work_load/_filters.erb
@@ -17,6 +17,34 @@
       <%= text_field_tag :workload_start_date, @today, :name => 'workload[start_date]', :size => 10 %>
       <%= calendar_for('workload_start_date') %>
     </div>
+
+    <!-- DX_Sadaf: adding select box for groups -->
+    <div class="groups">
+      <%= label_tag :workload_groups, l(:workload_show_filter_groups) %>
+      <div class="group-checkboxes">
+        <% @groups.each do |g| %>
+            <%
+               checked = false
+               unless group_params_nil?
+                 if params[:workload][:groups].include?("#{g.id}")
+                   checked = "checked"
+                 end
+               end
+            %>
+            <%= "<div class='group-checkbox'>#{check_box_tag("workload[groups][]" ,g.id,checked )} #{label_tag :group_name, g.name } </div>".html_safe %>
+        <% end %>
+        <div class="clear"></div>
+
+        <div>
+          <a id="workload_select_all" class='select-all' >Select All</a> |
+          <a id="workload_select_none" class='select-none'>Select None</a> |
+            <span class="selected-count">
+              <%= @usersToDisplay.length > 0 ? @usersToDisplay.length : "0" %>
+              members selected</span>
+        </div>
+      </div>
+    </div>
+
     <div class="users">
       <%= label_tag :workload_users, l(:workload_show_filter_user) %>
       <%= select_tag :workload_users, get_option_tags_for_userselection(@usersAllowedToDisplay, @usersToDisplay), :name => 'workload[users][]', :multiple => true %>
@@ -26,3 +54,10 @@
 <%
   end
 %>
+
+
+
+<script language="JavaScript">
+    var group_members = <%= @groups.as_json(include: :users).to_json.html_safe %>
+
+</script>

--- a/app/views/work_load/show.html.erb
+++ b/app/views/work_load/show.html.erb
@@ -1,3 +1,6 @@
+<%= javascript_include_tag 'groups', :plugin => 'redmine_workload' %>
+<%= stylesheet_link_tag 'groups', :plugin => 'redmine_workload' %>
+
 <% html_title(l(:workload_site_title)) %>
 
 <h2><%= l(:workload_show_label) %></h2>

--- a/assets/javascripts/groups.js
+++ b/assets/javascripts/groups.js
@@ -1,0 +1,48 @@
+/**
+ * Created by dx-sadaf on 2/23/15.
+ */
+
+jQuery(document).ready(function (){
+    $('input[type=checkbox][id^="workload_groups_"]').change(function (){
+        var $this = $(this);
+        //var group_id = $this.attr("id").substr(16);
+        var group_id = $this.val();
+        $.each(group_members,function (i, gp){
+            gp = gp.group;
+            if(gp.id == group_id){
+                var checked = $this.is(":checked");
+                $.each(gp.users, function (j,usr){
+                    if(checked){
+                        $("select#workload_users option[value='"+usr.id+"']").attr("selected", "selected");
+                    }else{
+                        $("select#workload_users option[value='"+usr.id+"']").removeAttr("selected")
+                    }
+                });
+            }
+        });
+
+        $('.selected-count').html( $("select#workload_users option:selected").length + " selected members" );
+    });
+
+    $('#workload_select_none').click(function (){
+        $("select#workload_users option").removeAttr("selected");
+        $('input[type=checkbox][id^="workload_groups_"]').removeAttr("checked");
+        $('.selected-count').html( $("select#workload_users option:selected").length + " selected members" );
+        return false;
+    });
+
+    $('#workload_select_all').click(function (){
+
+        $("select#workload_users option").attr("selected","selected");
+        $('input[type=checkbox][id^="workload_groups_"]').attr("checked","checked");
+        $('.selected-count').html( $("select#workload_users option:selected").length + " selected members" );
+        return false;
+    });
+
+	$("select#workload_users").change(function (){
+		$('.selected-count').html( $("select#workload_users option:selected").length + " selected members" );
+		return true;
+	});
+
+
+});

--- a/assets/stylesheets/groups.css
+++ b/assets/stylesheets/groups.css
@@ -1,0 +1,19 @@
+
+.groups{
+    margin-top:10px;
+}
+
+.group-checkboxes{
+    margin-left:150px;
+}
+.select-all, .select-none{
+    cursor: pointer;
+}
+
+.select-all, .select-none, .selected-count {
+    margin:10px 0px;
+}
+
+.group-checkbox{
+    float:left;margin: 0px 5px 10px 5px;
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,7 @@ en:
   workload_show_rangeto: "until"
   workload_show_today: "Use as \"today\":"
   workload_show_filter_user: "Users:"
+  workload_show_filter_groups: "Groups:"
   workload_show_issues: "Show issues:"
   workload_show_invisible_issues: "Issues invisible to you:"
   workload_show_issue_estimated_hours: "Estimated"


### PR DESCRIPTION
It is difficult to select users one by one, specially, if you have 50+ users. I added checkboxes representing groups in the workload filters, just above user's select box. Using these checkboxes makes it easier to select users.